### PR TITLE
Fix memo merge to 11-tree-efficiency

### DIFF
--- a/lec_2-Optimization/gen_knapsack.py
+++ b/lec_2-Optimization/gen_knapsack.py
@@ -219,7 +219,7 @@ def bruteKnapsack(inputs: list, constraint : float, valueFunction, costFunction)
     
     return (max_value, opt_list)
 
-def recursiveKnapsack(consider: list, avail: float, taken: tuple = (), val: float = 0, memo={}) -> list:
+def recursiveKnapsack(consider: list, avail: float, taken: tuple = (), val: float = 0, **recSet) -> list:
     """  
     Description: function to optimize knapsack case using recursive programming
 
@@ -236,7 +236,14 @@ def recursiveKnapsack(consider: list, avail: float, taken: tuple = (), val: floa
 
     return : list = [[consideration left over], available_left: float, (optimized Thing), optimized_value: float]
     """
+    k = {'go': False, 'recMemo' : {}}
+    for i in recSet:
+        if i in k:
+            k[i] = recSet[i]
     
+    if k['go'] == False : k['recMemo'] = {}
+    memo = k['recMemo']
+
     if consider == [] or avail == 0 :
         if len(taken) > 0 : return [consider, avail, taken, val, memo]
         # add nothing since there are nothing to be added anymore
@@ -245,24 +252,24 @@ def recursiveKnapsack(consider: list, avail: float, taken: tuple = (), val: floa
         # insufficient available capacity to stored the next thing in the scenario
         # WRONG: set value to be 0 because this should not even considered
         # CORRECT: only consider the right side only, val is not changing since not included consider[0]
-        return recursiveKnapsack(consider[1:], avail, taken, val, memo)
+        return recursiveKnapsack(consider[1:], avail, taken, val, recMemo=memo, go=True)
     else :
         consThing = consider[0]
         nextAvail = avail - consThing.getCost()
         if not('calls' in memo): memo['calls'] = 0
         memo['calls'] += 1
-        cons_1, avail_1, taken_1, val_1, memo = recursiveKnapsack(consider[1:], nextAvail, taken, val, memo)
+        cons_1, avail_1, taken_1, val_1, memo = recursiveKnapsack(consider[1:], nextAvail, taken, val, recMemo=memo, go=True)
         # this is basically reverse added the thing thus the value which thing is added is get added with consThing here
         # remember things are added here not included during the recursive calls
         val_1 += consThing.getValue()
 
         memo['calls'] += 1
-        cons_2, avail_2, taken_2, val_2, memo = recursiveKnapsack(consider[1:], avail, taken, val, memo)
+        cons_2, avail_2, taken_2, val_2, memo = recursiveKnapsack(consider[1:], avail, taken, val, recMemo=memo, go=True)
 
         if val_2 < val_1 : return [cons_1, avail_1, (*taken_1, consThing), val_1, memo]
         else : return [cons_2, avail_2, taken_2, val_2, memo]
 
-def dynamicKnapsack(consider: list, avail: list, taken: tuple = (), val: float = 0, memo={})-> list:
+def dynamicKnapsack(consider: list, avail: list, taken: tuple = (), val: float = 0, memo={}, **dynSet)-> list:
     """  
     Description: function to optimize knapsack case using recursive programming
 
@@ -279,6 +286,13 @@ def dynamicKnapsack(consider: list, avail: list, taken: tuple = (), val: float =
 
     return : list = [[consideration left over], available_left: float, (optimized Thing), optimized_value: float]
     """
+    j = {'go': False}
+    for i in dynSet:
+        if i in j:
+            j[i] = dynSet[i]
+    
+    if not(j['go']): memo = {}
+
     # here is the difference from the recursive one:
     if (len(consider), avail) in memo : 
         if not('pull' in memo): memo['pull'] = 0
@@ -293,19 +307,19 @@ def dynamicKnapsack(consider: list, avail: list, taken: tuple = (), val: float =
         # insufficient available capacity to stored the next thing in the scenario
         # WRONG: set value to be 0 because this should not even considered
         # CORECT: only consider the right side:
-        return dynamicKnapsack(consider[1:], avail, taken, val, memo)
+        return dynamicKnapsack(consider[1:], avail, taken, val, memo, go=True)
     else :
         consThing = consider[0]
         nextAvail = avail - consThing.getCost()
         if not('calls' in memo): memo['calls'] = 0
         memo['calls'] += 1
-        cons_1, avail_1, taken_1, val_1, memo = dynamicKnapsack(consider[1:], nextAvail, taken, val, memo)
+        cons_1, avail_1, taken_1, val_1, memo = dynamicKnapsack(consider[1:], nextAvail, taken, val, memo, go=True)
         # this is reverse taking things so added things add Value after recursive calls here 
         # remember things are added here not included during the recursive calls
         val_1 += consThing.getValue()
 
         memo['calls'] += 1
-        cons_2, avail_2, taken_2, val_2, memo = dynamicKnapsack(consider[1:], avail, taken, val, memo)
+        cons_2, avail_2, taken_2, val_2, memo = dynamicKnapsack(consider[1:], avail, taken, val, memo, go=True)
 
         if val_2 < val_1 : 
             # here is when we took the memo

--- a/lec_2-Optimization/gen_knapsack.py
+++ b/lec_2-Optimization/gen_knapsack.py
@@ -269,7 +269,7 @@ def recursiveKnapsack(consider: list, avail: float, taken: tuple = (), val: floa
         if val_2 < val_1 : return [cons_1, avail_1, (*taken_1, consThing), val_1, memo]
         else : return [cons_2, avail_2, taken_2, val_2, memo]
 
-def dynamicKnapsack(consider: list, avail: list, taken: tuple = (), val: float = 0, memo={}, **dynSet)-> list:
+def dynamicKnapsack(consider: list, avail: list, taken: tuple = (), val: float = 0, **dynSet)-> list:
     """  
     Description: function to optimize knapsack case using recursive programming
 
@@ -286,12 +286,13 @@ def dynamicKnapsack(consider: list, avail: list, taken: tuple = (), val: float =
 
     return : list = [[consideration left over], available_left: float, (optimized Thing), optimized_value: float]
     """
-    j = {'go': False}
+    j = {'go': False, 'dynMemo' : {}}
     for i in dynSet:
         if i in j:
             j[i] = dynSet[i]
     
-    if not(j['go']): memo = {}
+    if not(j['go']): j['dynMemo'] = {}
+    memo = j['dynMemo']
 
     # here is the difference from the recursive one:
     if (len(consider), avail) in memo : 
@@ -307,19 +308,19 @@ def dynamicKnapsack(consider: list, avail: list, taken: tuple = (), val: float =
         # insufficient available capacity to stored the next thing in the scenario
         # WRONG: set value to be 0 because this should not even considered
         # CORECT: only consider the right side:
-        return dynamicKnapsack(consider[1:], avail, taken, val, memo, go=True)
+        return dynamicKnapsack(consider[1:], avail, taken, val, dynMemo = memo, go=True)
     else :
         consThing = consider[0]
         nextAvail = avail - consThing.getCost()
         if not('calls' in memo): memo['calls'] = 0
         memo['calls'] += 1
-        cons_1, avail_1, taken_1, val_1, memo = dynamicKnapsack(consider[1:], nextAvail, taken, val, memo, go=True)
+        cons_1, avail_1, taken_1, val_1, memo = dynamicKnapsack(consider[1:], nextAvail, taken, val, dynMemo = memo, go=True)
         # this is reverse taking things so added things add Value after recursive calls here 
         # remember things are added here not included during the recursive calls
         val_1 += consThing.getValue()
 
         memo['calls'] += 1
-        cons_2, avail_2, taken_2, val_2, memo = dynamicKnapsack(consider[1:], avail, taken, val, memo, go=True)
+        cons_2, avail_2, taken_2, val_2, memo = dynamicKnapsack(consider[1:], avail, taken, val, dynMemo = memo, go=True)
 
         if val_2 < val_1 : 
             # here is when we took the memo

--- a/test/test_gen_knapsack.py
+++ b/test/test_gen_knapsack.py
@@ -223,6 +223,7 @@ class TestDynamicKnapsack(unittest.TestCase):
     def test_simple_things_on_recursive_knapsack(self):
         # arrange
         print_out = '<c; value: 8.0; weight: 2.0>\n<b; value: 7.0; weight: 3.0>\n'
+        # NOTE: c is printed prior to b because the recursive algorithm steps is adding things backward 
         expected_total_value = 15.0
 
         cap = io.StringIO()
@@ -309,14 +310,14 @@ class TestDynamicKnapsack(unittest.TestCase):
         'beer' : [90, 154],
         'pizza' : [30, 154],
         'burger' : [50, 354],
-        # 'fries' : [90, 365], <- this is must have
+        # 'fries' : [90, 365], <- this is must have, thus omitted from datas
         'coke' : [79, 150],
         'apple' : [90, 95],
         'donut' : [10, 195]
         }
 
         foods = gk.buildThings(datas, cost_custom='calories')
-        fries = gk.Thing('fries', 90.0, 365, cost_name='calories')
+        fries = gk.Thing('fries', 90.0, 365, cost_name='calories') #create Thiung that omitted from datas
         must_have = (fries,)
         constraint = 750
 


### PR DESCRIPTION
I think this is the best solution. Keep the memo inside kwargs and make sure to always starts with empty dict as memo